### PR TITLE
fixed and frozed broken dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "parseurl": "^1.3.0",
     "react": "0.13.2",
-    "reapp-kit": "^1.2.0",
+    "reapp-kit": "1.2.15",
+    "reapp-ui": "0.12.54",
     "reapp-reducer": "^1.0.0"
   }
 }


### PR DESCRIPTION
When trying to install this app I get the following error:

```
npm ERR! Linux 3.19.0-49-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "i"
npm ERR! node v4.3.1
npm ERR! npm  v2.14.12
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react@0.14.7 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer omniscient@3.3.0 wants react@>=0.12.0 || >=0.14.0-alpha
npm ERR! peerinvalid Peer react-router@0.13.5 wants react@0.13.x||0.14.x
npm ERR! peerinvalid Peer reapp-routes@0.10.12 wants react@0.13.x
npm ERR! peerinvalid Peer reapp-ui@0.12.70 wants react@0.14.x
```

clearly reapp-ui is indirectly being installed by one of the other deps and as you can see it really doesn't play nice with the rest of them. It's much, much better to directly add it as a dependency so this sort of thing doesn't happen. The app hasn't been updated in a long time so frozen dependencies are probably the way to go.

I've followed the following advice from the reapp [README](https://github.com/reapp/reapp/blob/master/README.md):

---

If you run into a blank page after `reapp run`, try these commands.

``` bash
npm install --save react@0.13.2
npm install --save reapp-ui@0.12.54
npm install --save reapp-kit@1.2.15
```

---

Using node v5.1.0
npm v2.14.12
reapp cli tool v0.8.28
Ubuntu 14.10 
